### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ AI agents with filesystem and shell access can delete files, leak credentials, o
 
 `ai-runtime-guard` is an MCP server that sits between your AI agent and your system, enforcing a policy layer before any file or shell action takes effect. No retraining, no prompt engineering, no changes to your agent or workflow, just install, configure once, and your agent operates within the boundaries you set.
 
+[![ai-runtime-guard MCP server](https://glama.ai/mcp/servers/jimmyracheta/ai-runtime-guard/badges/card.svg)](https://glama.ai/mcp/servers/jimmyracheta/ai-runtime-guard)
+
 ## What it does
 1. **Blocks dangerous operations**: `rm -rf`, sensitive file access, privilege escalation, and more are denied before execution.
 2. **Gates risky commands behind human approval (optional)**: configurable commands require explicit operator sign-off via a web GUI before the agent can proceed.


### PR DESCRIPTION
This PR adds a badge for the [ai-runtime-guard](https://glama.ai/mcp/servers/jimmyracheta/ai-runtime-guard) server listing in Glama MCP server directory.

[![ai-runtime-guard MCP server](https://glama.ai/mcp/servers/jimmyracheta/ai-runtime-guard/badges/card.svg)](https://glama.ai/mcp/servers/jimmyracheta/ai-runtime-guard)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.